### PR TITLE
Storage ng

### DIFF
--- a/src/offchainapi/asyncnet.py
+++ b/src/offchainapi/asyncnet.py
@@ -94,7 +94,7 @@ class Aionet:
                                 f'failed with error: {str(e)}'
                             )
 
-                    len_my = len(channel.my_request_index)
+                    len_my = len(list(channel.my_request_index.keys()))
                     logger.info(
                         f'''
                         Channel: {me.as_str()} [{role}] <-> {other.as_str()}

--- a/src/offchainapi/asyncnet.py
+++ b/src/offchainapi/asyncnet.py
@@ -224,7 +224,9 @@ class Aionet:
 
                 # Check that there are no low-level HTTP errors.
                 if response.status != 200 :
-                    err_msg = f'Received status {response.status}: {response.text()}'
+                    response_text = await response.text()
+                    response = channel.parse_response(response_text)
+                    err_msg = f'Received status {response.status}: {response}'
                     raise Exception(err_msg)
 
                 response_text = await response.text()

--- a/src/offchainapi/errors.py
+++ b/src/offchainapi/errors.py
@@ -32,6 +32,10 @@ class OffChainErrorCode(Enum):
     # Indicates that the signature verification failed
     invalid_signature = 'invalid_signature'
 
+    # One of the dependencies is missing -- this is recoverable if it becomes
+    # available down the line. Whence it is a protocol error only.
+    missing_dependencies = 'missing_dependencies'
+
     # Codes for command errors
     # ------------------------
     #
@@ -43,7 +47,8 @@ class OffChainErrorCode(Enum):
     # used by another command. As a result committing this command may result in
     # a conflict / inconsistent state. The command is therefore permanantly
     # rejected with an idempotent command error.
-    missing_dependencies = 'missing_dependencies'
+
+    used_dependencies    = 'used_dependencies'
 
 
     # Payment command error codes

--- a/src/offchainapi/payment_logic.py
+++ b/src/offchainapi/payment_logic.py
@@ -57,21 +57,21 @@ class PaymentProcessor(CommandProcessor):
         # The processor state -- only access through event loop to prevent
         # mutlithreading bugs.
         self.storage_factory = storage_factory
-        with self.storage_factory.atomic_writes():
-            root = storage_factory.make_value('processor', None)
-            self.reference_id_index = storage_factory.make_dict(
-                'reference_id_index', PaymentObject, root)
 
-            # This is the primary store of shared objects.
-            # It maps version numbers -> objects.
-            self.object_store = storage_factory.make_dict(
-                'object_store', SharedObject, root=root)
+        root = storage_factory.make_dir('processor')
+        self.reference_id_index = storage_factory.make_dict(
+            'reference_id_index', PaymentObject, root)
 
-            # Persist those to enable crash-recovery
-            self.pending_commands = storage_factory.make_dict(
-                'pending_commands', str, root)
-            self.command_cache = storage_factory.make_dict(
-                'command_cache', ProtocolCommand, root)
+        # This is the primary store of shared objects.
+        # It maps version numbers -> objects.
+        self.object_store = storage_factory.make_dict(
+            'object_store', SharedObject, root=root)
+
+        # Persist those to enable crash-recovery
+        self.pending_commands = storage_factory.make_dict(
+            'pending_commands', str, root)
+        self.command_cache = storage_factory.make_dict(
+            'command_cache', ProtocolCommand, root)
 
         # Allow mapping a set of future to payment reference_id outcomes
         # Once a payment has an outcome (ready_for_settlement, abort, or command exception)

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -203,15 +203,16 @@ class VASPPairChannel:
         """
         return self.vasp
 
-    def next_final_sequence(self):
-        """
-        Returns:
-            int: The number of items in the sequence of successful commands.
-        """
-        return len(self.command_sequence)
 
     if __debug__:
         # Only used for testing -- should not be used in production.
+
+        def next_final_sequence(self):
+            """
+            Returns:
+                int: The number of items in the sequence of successful commands.
+            """
+            return len(self.command_sequence)
 
 
         def get_final_sequence(self):
@@ -325,7 +326,7 @@ class VASPPairChannel:
         self.processor.process_command(
             other_addr=other_addr,
             command=request.command,
-            seq=self.next_final_sequence(),
+            seq=request.cid,
             status_success=request.is_success(),
             error=response.error if response.error else None
         )
@@ -497,9 +498,14 @@ class VASPPairChannel:
                      for dv in depends_on_version
                      if dv in self.object_locks}
 
+        if any(dv not in obj_locks for dv in depends_on_version):
+            # Some dependencies are missing but may becomes available later?
+            response = make_protocol_error(
+                request, code=OffChainErrorCode.wait)
+            return response
+
         # Check all dependencies are here and not used.
-        has_all_deps = all(dv in obj_locks and
-                           obj_locks[dv] != 'False'
+        has_all_deps = all(obj_locks[dv] != 'False'
                            for dv in depends_on_version)
 
         # If one of the dependency is locked then wait.
@@ -519,7 +525,15 @@ class VASPPairChannel:
         # Option 1: raise due to missing deps
         if not has_all_deps:
             response = make_command_error(
-                request, code=OffChainErrorCode.missing_dependencies)
+                request, code=OffChainErrorCode.used_dependencies)
+
+            # Record the error in the log
+            logger.error(f'Reject request {request.cid} -- missing dependencies')
+            for dv in depends_on_version:
+                if dv not in obj_locks:
+                    logger.error(f' Key {dv} not found')
+                else:
+                    logger.error(f' Key {dv} = {obj_locks[dv]}')
 
         else:
 
@@ -569,12 +583,16 @@ class VASPPairChannel:
             for cv in create_versions:
                 self.object_locks[cv] = 'True'
 
+            logger.debug(f'[{self.role()}] Dependency update: {depends_on_version} -> {create_versions}')
+
         else:
             for dv in depends_on_version:
                 # The depedency may not be in the locks, since the failure
                 # may have been due to a missing dependency.
                 if dv in self.object_locks and self.object_locks[dv] == request.cid:
                     self.object_locks[dv] = 'True'
+
+            logger.debug(f'[{self.role()}] Dependency no update: {depends_on_version} -> {create_versions}')
 
     def parse_response(self, response_text):
             vasp = self.get_vasp()

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -176,9 +176,6 @@ class VASPPairChannel:
             self.my_request_index = self.storage.make_dict(
                         'my_request_index', CommandRequestObject,
                         root=other_vasp)
-            self.other_request_index = self.storage.make_dict(
-                        'other_request_index', CommandRequestObject,
-                        root=other_vasp)
 
             # Indicates for a request cid if a response has been received.
             self.pending_response = self.storage.make_dict(
@@ -214,16 +211,20 @@ class VASPPairChannel:
         """
         return len(self.command_sequence)
 
-    def get_final_sequence(self):
-        """
-        Returns:
-            list: The sequence of successful commands.
-        """
-        command_list = []
-        for cid in self.command_sequence.keys():
-            command_list += [ self.command_sequence[cid] ]
+    if __debug__:
+        # Only used for testing -- should not be used in production.
 
-        return command_list
+
+        def get_final_sequence(self):
+            """
+            Returns:
+                list: The sequence of successful commands.
+            """
+            command_list = []
+            for cid in self.command_sequence.keys():
+                command_list += [ self.command_sequence[cid] ]
+
+            return command_list
 
     def package_request(self, request):
         """ A hook to send a request to other VASP.
@@ -463,8 +464,8 @@ class VASPPairChannel:
         depends_on_version = request.command.get_dependencies()
 
         # Always answer old requests.
-        if request.cid in self.other_request_index:
-            previous_request = self.other_request_index[request.cid]
+        if request.cid in self.command_sequence:
+            previous_request = self.command_sequence[request.cid]
             if previous_request.has_response():
                 if previous_request.is_same_command(request):
 
@@ -546,7 +547,6 @@ class VASPPairChannel:
 
         # Update the index of others' requests
         self.command_sequence[request.cid] = request
-        self.other_request_index[request.cid] = request
         self.register_dependencies(request)
         self.apply_response(request)
 

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -156,7 +156,7 @@ class VASPPairChannel:
 
             # The common sequence of commands and their
             # status for those committed.
-            self.command_sequence = self.storage.make_list(
+            self.command_sequence = self.storage.make_dict(
                 'command_sequence', CommandRequestObject, root=other_vasp
             )
 
@@ -219,7 +219,11 @@ class VASPPairChannel:
         Returns:
             list: The sequence of successful commands.
         """
-        return self.command_sequence
+        command_list = []
+        for cid in self.command_sequence.keys():
+            command_list += [ self.command_sequence[cid] ]
+
+        return command_list
 
     def package_request(self, request):
         """ A hook to send a request to other VASP.
@@ -541,7 +545,7 @@ class VASPPairChannel:
         request.response = response
 
         # Update the index of others' requests
-        self.command_sequence += [request]
+        self.command_sequence[request.cid] = request
         self.other_request_index[request.cid] = request
         self.register_dependencies(request)
         self.apply_response(request)
@@ -672,7 +676,7 @@ class VASPPairChannel:
         del self.pending_response[request.cid]
 
         # Add the next command to the common sequence.
-        self.command_sequence += [request]
+        self.command_sequence[request.cid] = request
         self.my_request_index[request_seq] = request
         self.register_dependencies(request)
         self.apply_response(request)

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -212,7 +212,7 @@ class VASPPairChannel:
             Returns:
                 int: The number of items in the sequence of successful commands.
             """
-            return len(self.command_sequence)
+            return len(list(self.command_sequence.keys()))
 
 
         def get_final_sequence(self):
@@ -722,7 +722,7 @@ class VASPPairChannel:
         """ Returns true if there are any pending re-transmits, namely
             requests for which the response has not yet been received.
         """
-        return len(self.my_request_index) > 0
+        return not self.my_request_index.is_empty()
 
     def pending_retransmit_number(self):
         '''
@@ -730,4 +730,4 @@ class VASPPairChannel:
             the number of requests that are waiting to be
             retransmitted on this channel.
         '''
-        return len(self.my_request_index)
+        return len(list(self.my_request_index.keys()))

--- a/src/offchainapi/sample/sample_service.py
+++ b/src/offchainapi/sample/sample_service.py
@@ -9,7 +9,7 @@ from ..protocol_messages import CommandRequestObject, OffChainProtocolError, \
     OffChainException
 from ..payment_logic import PaymentCommand, PaymentProcessor
 from ..status_logic import Status
-from ..storage import StorableFactory
+from ..storage import StorableFactory, BasicStore
 from ..crypto import ComplianceKey
 from ..errors import OffChainErrorCode
 
@@ -236,7 +236,7 @@ class sample_vasp:
     def __init__(self, my_addr):
         self.my_addr = my_addr
         self.bc = sample_business(self.my_addr)
-        self.store        = StorableFactory({})
+        self.store        = StorableFactory(BasicStore.mem())
         self.info_context = sample_vasp_info()
 
         self.pp = PaymentProcessor(self.bc, self.store)

--- a/src/offchainapi/shared_object.py
+++ b/src/offchainapi/shared_object.py
@@ -39,7 +39,7 @@ class SharedObject(JSONSerializable):
         Returns:
             SharedObject: The new shared obeject.
         """
-        if store:
+        if store is not None and self.version in store:
             clone = store[self.version]
         else:
             clone = deepcopy(self)

--- a/src/offchainapi/storage.py
+++ b/src/offchainapi/storage.py
@@ -4,8 +4,6 @@
 # The main storage interface.
 
 import json
-from threading import RLock
-
 from .utils import JSONFlag, JSONSerializable, get_unique_string
 
 
@@ -61,7 +59,6 @@ class StorableFactory:
     '''
 
     def __init__(self, db):
-        self.rlock = RLock()
         self.db = db
         self.current_transaction = None
         self.levels = 0
@@ -231,20 +228,17 @@ class StorableFactory:
         return self
 
     def __enter__(self):
-        self.rlock.acquire()
         if self.levels == 0:
             self.current_transaction = get_unique_string()
 
         self.levels += 1
 
     def __exit__(self, type, value, traceback):
-        try:
-            self.levels -= 1
-            if self.levels == 0:
-                self.current_transaction = None
-                self.persist_cache()
-        finally:
-            self.rlock.release()
+        self.levels -= 1
+        if self.levels == 0:
+            self.current_transaction = None
+            self.persist_cache()
+
 
 
 class StorableDict(Storable):

--- a/src/offchainapi/storage.py
+++ b/src/offchainapi/storage.py
@@ -277,7 +277,6 @@ class StorableDict(Storable):
             db, '__FIRST_KEY', str,
             root=meta, default='_NONE')
         self.first_key.debug = True
-        self.length = StorableValue(db, '__LEN', int, root=meta, default=0)
 
     if __debug__:
         def _check_invariant(self):
@@ -327,9 +326,6 @@ class StorableDict(Storable):
 
         # Ensure nothing fails after that
         if db_key not in self.db:
-            xlen = self.length.get_value()
-            self.length.set_value(xlen+1)
-
             # Add an entry to the linked list
             self._ll_cons(key)
 
@@ -360,8 +356,6 @@ class StorableDict(Storable):
 
     def __len__(self):
         raise RuntimeError('Tried to get len of storable dict.')
-        xlen = self.length.get_value()
-        return xlen
 
     def is_empty(self):
         ''' Returns True if dict is empty and False if it contains some elements.'''
@@ -372,8 +366,6 @@ class StorableDict(Storable):
     def __delitem__(self, key):
         db_key, db_key_LL = self.derive_keys(key)
         if db_key in self.db:
-            xlen = self.length.get_value()
-            self.length.set_value(xlen-1)
             del self.db[db_key]
 
             # Now fix the LL structure

--- a/src/offchainapi/storage.py
+++ b/src/offchainapi/storage.py
@@ -359,8 +359,15 @@ class StorableDict(Storable):
             yield self[k]
 
     def __len__(self):
+        raise RuntimeError('Tried to get len of storable dict.')
         xlen = self.length.get_value()
         return xlen
+
+    def is_empty(self):
+        ''' Returns True if dict is empty and False if it contains some elements.'''
+        for _ in self.keys():
+            return False
+        return True
 
     def __delitem__(self, key):
         db_key, db_key_LL = self.derive_keys(key)

--- a/src/offchainapi/tests/conftest.py
+++ b/src/offchainapi/tests/conftest.py
@@ -3,7 +3,7 @@
 
 from ..payment import PaymentActor, PaymentAction, PaymentObject, KYCData, StatusObject
 from ..business import BusinessContext, VASPInfo
-from ..storage import StorableFactory
+from ..storage import StorableFactory, BasicStore
 from ..payment_logic import Status, PaymentProcessor, PaymentCommand
 from ..protocol import OffChainVASP, VASPPairChannel
 from ..command_processor import CommandProcessor
@@ -65,8 +65,8 @@ def kyc_data():
 
 
 @pytest.fixture
-def store():
-    return StorableFactory({})
+def store(db):
+    return StorableFactory(db)
 
 
 @pytest.fixture
@@ -113,9 +113,11 @@ def two_channels(three_addresses, vasp, store):
 
 @pytest.fixture
 def db(tmp_path):
+    import sqlite3
+
     db_path = tmp_path / 'db.dat'
-    with dbm.open(str(db_path), 'c') as xdb:
-        yield xdb
+    db = BasicStore(sqlite3.connect(str(db_path)))
+    yield db
 
 
 @pytest.fixture

--- a/src/offchainapi/tests/local_benchmark.py
+++ b/src/offchainapi/tests/local_benchmark.py
@@ -129,7 +129,7 @@ async def main_perf(messages_num=10, wait_num=0, verbose=False):
 
     async def wait_for_all_payment_outcome(nodeA, payments, results):
         fut_list = [nodeA.wait_for_payment_outcome_async(
-            p.reference_id, timeout=None) for p,r in zip(payments, results)]
+            p.reference_id, timeout=60.0) for p,r in zip(payments, results)]
 
         res = await asyncio.gather(
                 *fut_list,
@@ -161,7 +161,7 @@ async def main_perf(messages_num=10, wait_num=0, verbose=False):
             if not isinstance(out, Exception):
                 print('OUT OK:', out.sender.status.as_status(), out.receiver.status.as_status())
             else:
-                print('OUT NOTOK:', str(out))
+                print('OUT NOTOK:', type(out), str(out))
 
     print('All payments done.')
 

--- a/src/offchainapi/tests/local_benchmark.py
+++ b/src/offchainapi/tests/local_benchmark.py
@@ -14,6 +14,7 @@ from ..payment import PaymentAction, PaymentActor, PaymentObject, StatusObject
 from ..core import Vasp
 from .basic_business_context import TestBusinessContext
 from ..crypto import ComplianceKey
+from ..storage import BasicStore
 
 from threading import Thread
 import time
@@ -77,7 +78,7 @@ def make_new_VASP(Peer_addr, port, reliable=True):
         port=port,
         business_context=TestBusinessContext(Peer_addr, reliable=reliable),
         info_context=SimpleVASPInfo(Peer_addr),
-        database={})
+        database=BasicStore.mem())
 
     loop = asyncio.new_event_loop()
     VASPx.set_loop(loop)

--- a/src/offchainapi/tests/remote_benchmark.py
+++ b/src/offchainapi/tests/remote_benchmark.py
@@ -110,9 +110,9 @@ def run_server(my_configs_path, other_configs_path, num_of_commands=10, loop=Non
 
     def stop_server(vasp):
         channel = vasp.vasp.get_channel(other_addr)
-        requests = len(channel.command_sequence)
+        requests = len(list(channel.command_sequence.keys()))
         while requests < num_of_commands:
-            requests = len(channel.command_sequence)
+            requests = len(list(channel.command_sequence.keys()))
             time.sleep(0.1)
         vasp.close()
     Thread(target=stop_server, args=(vasp,)).start()

--- a/src/offchainapi/tests/remote_benchmark.py
+++ b/src/offchainapi/tests/remote_benchmark.py
@@ -12,6 +12,7 @@ from ..asyncnet import Aionet
 from ..core import Vasp
 from ..crypto import ComplianceKey
 from .basic_business_context import TestBusinessContext
+from ..storage import BasicStore
 
 import logging
 import json
@@ -96,7 +97,7 @@ def run_server(my_configs_path, other_configs_path, num_of_commands=10, loop=Non
         port=my_configs['port'],
         business_context=AsyncMock(spec=BusinessContext),
         info_context=SimpleVASPInfo(my_configs, other_configs),
-        database={}
+        database=BasicStore.mem()
     )
     logging.info(f'Created VASP {my_addr.as_str()}.')
 
@@ -156,7 +157,7 @@ def run_client(my_configs_path, other_configs_path, num_of_commands=10, port=0):
         port=my_configs['port'],
         business_context=TestBusinessContext(my_addr),
         info_context=SimpleVASPInfo(my_configs, other_configs, port),
-        database={}
+        database=BasicStore.mem()
     )
     logging.info(f'Created VASP {my_addr.as_str()}.')
 

--- a/src/offchainapi/tests/remote_benchmark.py
+++ b/src/offchainapi/tests/remote_benchmark.py
@@ -110,9 +110,9 @@ def run_server(my_configs_path, other_configs_path, num_of_commands=10, loop=Non
 
     def stop_server(vasp):
         channel = vasp.vasp.get_channel(other_addr)
-        requests = len(channel.other_request_index)
+        requests = len(channel.command_sequence)
         while requests < num_of_commands:
-            requests = len(channel.other_request_index)
+            requests = len(channel.command_sequence)
             time.sleep(0.1)
         vasp.close()
     Thread(target=stop_server, args=(vasp,)).start()

--- a/src/offchainapi/tests/test_payment_logic.py
+++ b/src/offchainapi/tests/test_payment_logic.py
@@ -282,8 +282,8 @@ def test_payment_process_get_extended_kyc(payment, processor, kyc_data):
     assert new_payment.receiver.kyc_data == kyc_data
 
 
-def test_persist(payment):
-    store = StorableFactory({})
+def test_persist(db, payment):
+    store = StorableFactory(db)
 
     my_addr = LibraAddress.from_bytes(b'A'*16)
     my_addr_str = my_addr.as_str()
@@ -317,8 +317,8 @@ def test_persist(payment):
     assert len(processor.list_command_obligations()) == 0
 
 
-def test_reprocess(payment,  loop):
-    store = StorableFactory({})
+def test_reprocess(db, payment,  loop):
+    store = StorableFactory(db)
 
     my_addr = LibraAddress.from_bytes(b'A'*16)
     my_addr_str = my_addr.as_str()
@@ -348,8 +348,8 @@ def test_reprocess(payment,  loop):
     assert len(processor.list_command_obligations()) == 0
 
 
-def test_process_command_success_no_proc(payment, loop):
-    store = StorableFactory({})
+def test_process_command_success_no_proc(db, payment, loop):
+    store = StorableFactory(db, )
 
     my_addr = LibraAddress.from_bytes(b'B'*16)
     other_addr = LibraAddress.from_bytes(b'A'*16)
@@ -366,8 +366,8 @@ def test_process_command_success_no_proc(payment, loop):
     coro = processor.process_command_success_async(other_addr, cmd, seq=10)
     _ = loop.run_until_complete(coro)
 
-def test_process_command_success_vanilla(payment, loop):
-    store = StorableFactory({})
+def test_process_command_success_vanilla(db, payment, loop):
+    store = StorableFactory(db)
 
     my_addr = LibraAddress.from_bytes(b'B'*16)
     other_addr = LibraAddress.from_bytes(b'A'*16)

--- a/src/offchainapi/tests/test_payment_logic_protocol.py
+++ b/src/offchainapi/tests/test_payment_logic_protocol.py
@@ -31,10 +31,10 @@ def payment_sender_init():
     payment = PaymentObject(sender, receiver, ref, None, None, action)
     return payment
 
-def test_logic_protocol_check(payment_sender_init, loop):
+def test_logic_protocol_check(db, payment_sender_init, loop):
     # Test the protocol given a sequence of commands.
 
-    store = StorableFactory({})
+    store = StorableFactory(db)
 
     my_addr = LibraAddress.from_bytes(b'B'*16)
     other_addr = LibraAddress.from_bytes(b'A'*16)
@@ -50,10 +50,10 @@ def test_logic_protocol_check(payment_sender_init, loop):
     processor.check_command(my_addr, other_addr, cmd)
 
 
-def test_logic_protocol_process_start(payment_sender_init, loop):
+def test_logic_protocol_process_start(db, payment_sender_init, loop):
     # Test the protocol given a sequence of commands.
 
-    store = StorableFactory({})
+    store = StorableFactory(db)
 
     my_addr = LibraAddress.from_bytes(b'B'*16)
     other_addr = LibraAddress.from_bytes(b'A'*16)

--- a/src/offchainapi/tests/test_payment_logic_protocol.py
+++ b/src/offchainapi/tests/test_payment_logic_protocol.py
@@ -66,13 +66,13 @@ def test_logic_protocol_process_start(payment_sender_init, loop):
     cmd = PaymentCommand(payment_sender_init)
     cmd.set_origin(other_addr)
 
-    assert len(processor.command_cache) == 0
+    assert processor.command_cache.is_empty()
 
     with store.atomic_writes():
         processor.process_command(other_addr, cmd, seq=0, status_success=True)
 
     # Ensure an obligration is scheduled
-    assert len(processor.command_cache) == 1
+    assert len(list(processor.command_cache.keys())) == 1
     assert len(asyncio.all_tasks(loop)) == 1
 
     # Get the response command

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -268,7 +268,7 @@ def test_protocol_server_client_interleaved_benign(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 0
+    assert client.my_request_index.is_empty()
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -292,7 +292,7 @@ def test_protocol_server_client_interleaved_swapped_request(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 0
+    assert len(list(client.my_request_index.keys())) == 0
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -387,7 +387,7 @@ def test_protocol_server_client_interleaved_swapped_reply(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 0
+    assert len(list(client.my_request_index.keys())) == 0
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -315,10 +315,10 @@ def test_protocol_conflict1(two_channels):
     msg3 = server.sequence_command_local(SampleCommand('World2', deps=['Hello']))
     msg3 = server.package_request(msg3).content
 
-    # Since this is not yet confirmed, reject the command
+    # Since this is not yet confirmed, make it wait
     msg4 = client.parse_handle_request(msg3).content
-    succ = server.parse_handle_response(msg4)
-    assert not succ  # Fails
+    with pytest.raises(OffChainProtocolError):
+        succ = server.parse_handle_response(msg4)
 
     # Now add the response that creates 'hello'
     succ = client.parse_handle_response(msg2)

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -138,8 +138,8 @@ class RandomRun(object):
         assert len(client_seq) == NUMBER - self.rejected
         assert set(client_seq) == set(server_seq)
 
-        client_exec_seq = [c.command.item() for c in client.command_sequence]
-        server_exec_seq = [c.command.item() for c in server.command_sequence]
+        client_exec_seq = [c.command.item() for c in client.get_final_sequence()]
+        server_exec_seq = [c.command.item() for c in server.get_final_sequence()]
         assert set(client_seq) == set(client_exec_seq)
         assert set(server_seq) == set(server_exec_seq)
 

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -183,10 +183,8 @@ def test_protocol_server_client_benign(two_channels):
     assert isinstance(request, CommandRequestObject)
 
     # Pass the request to the client
-    assert len(client.other_request_index) == 0
     reply = client.handle_request(request)
     assert isinstance(reply, CommandResponseObject)
-    assert len(client.other_request_index) == 1
     assert reply.status == 'success'
 
     # Pass the reply back to the server
@@ -214,7 +212,6 @@ def test_protocol_server_conflicting_sequence(two_channels):
     reply_conflict = client.handle_request(request_conflict)
 
     # We only sequence one command.
-    assert len(client.other_request_index) == 1
     assert reply.status == 'success'
 
     # The response to the second command is a failure
@@ -237,13 +234,10 @@ def test_protocol_client_server_benign(two_channels):
     # Create a server request for a command
     request = client.sequence_command_local(SampleCommand('Hello'))
     assert isinstance(request, CommandRequestObject)
-    assert len(client.other_request_index) == 0
 
     # Send to server
-    assert len(client.other_request_index) == 0
     reply = server.handle_request(request)
     assert isinstance(reply, CommandResponseObject)
-    assert len(server.other_request_index) == 1
     assert server.next_final_sequence() == 1
     assert server.next_final_sequence() > 0
 
@@ -275,7 +269,6 @@ def test_protocol_server_client_interleaved_benign(two_channels):
     client.handle_response(server_reply)
 
     assert len(client.my_request_index) == 1
-    assert len(server.other_request_index) == 1
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -300,7 +293,6 @@ def test_protocol_server_client_interleaved_swapped_request(two_channels):
     client.handle_response(server_reply)
 
     assert len(client.my_request_index) == 1
-    assert len(server.other_request_index) == 1
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -396,7 +388,6 @@ def test_protocol_server_client_interleaved_swapped_reply(two_channels):
     client.handle_response(server_reply)
 
     assert len(client.my_request_index) == 1
-    assert len(server.other_request_index) == 1
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -247,7 +247,7 @@ def test_protocol_client_server_benign(two_channels):
     assert succ
 
     assert client.next_final_sequence() > 0
-    assert client.my_request_index[request.cid].response is not None
+    assert client.command_sequence[request.cid].response is not None
     assert client.get_final_sequence()[0].command.item() == 'Hello'
     assert client.next_final_sequence() == 1
 
@@ -268,7 +268,7 @@ def test_protocol_server_client_interleaved_benign(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 1
+    assert len(client.my_request_index) == 0
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -292,7 +292,7 @@ def test_protocol_server_client_interleaved_swapped_request(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 1
+    assert len(client.my_request_index) == 0
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {
@@ -387,7 +387,7 @@ def test_protocol_server_client_interleaved_swapped_reply(two_channels):
 
     client.handle_response(server_reply)
 
-    assert len(client.my_request_index) == 1
+    assert len(client.my_request_index) == 0
     assert len(client.get_final_sequence()) == 2
     assert len(server.get_final_sequence()) == 2
     assert {c.command.item() for c in client.get_final_sequence()} == {

--- a/src/offchainapi/tests/test_storable.py
+++ b/src/offchainapi/tests/test_storable.py
@@ -90,62 +90,24 @@ def test_dict_index():
     assert 'x' not in D
 
 
-def test_value():
-    # Test default
-    db = BasicStore.mem()
-    db.can_write = True
-
-    val0 = StorableValue(db, 'counter_zero', int, default=0)
-    assert val0.get_value() == 0
-    assert val0.exists()
-    val0.set_value(10)
-    assert val0.get_value() == 10
-
-    val = StorableValue(db, 'counter', int)
-    assert val.exists() is False
-    val.set_value(10)
-    assert val.exists() is True
-
-    val2 = StorableValue(db, 'counter', int)
-    assert val2.exists() is True
-    assert val2.get_value() == 10
-
-
-def test_value_dict():
-    db = BasicStore.mem()
-    db.can_write = True
-
-    val = StorableValue(db, 'counter', int)
-    assert val.exists() is False
-    val.set_value(10)
-    assert val.exists() is True
-
-    val2 = StorableValue(db, 'counter', int)
-    assert val2.exists() is True
-    assert val2.get_value() == 10
-
-
 def test_hierarchy():
     db = BasicStore.mem()
     db.can_write = True
 
-    val = StorableValue(db, 'counter', int)
-    val.set_value(10)
+    val = StorableValue(db, 'counter', None)
 
-    val2 = StorableValue(db, 'counter', int, root=val)
-    assert val2.exists() is False
-    val2.set_value(20)
-    assert val.get_value() == 10
-    assert val2.get_value() == 20
+    val2 = StorableDict(db, 'counter', int, root=val)
+
+    val2['xx'] = 20
+    assert val2['xx'] == 20
 
 
 def test_value_payment(db, payment):
     db.can_write = True
-    val = StorableValue(db, 'payment', payment.__class__)
-    assert val.exists() is False
-    val.set_value(payment)
-    assert val.exists() is True
-    pay2 = val.get_value()
+    val = StorableDict(db, 'payment', payment.__class__)
+
+    val['name'] = payment
+    pay2 = val['name']
     assert payment == pay2
 
     D = StorableDict(db, 'mary', payment.__class__)
@@ -158,14 +120,14 @@ def test_value_command(db, payment):
 
     cmd = PaymentCommand(payment)
 
-    val = StorableValue(db, 'command', PaymentCommand)
-    val.set_value(cmd)
-    assert val.get_value() == cmd
+    val = StorableDict(db, 'command', PaymentCommand)
+    val['name'] = cmd
+    assert val['name'] == cmd
 
     cmd.writes_version_map = [('xxxxxxxx', 'xxxxxxxx')]
-    assert val.get_value() != cmd
-    val.set_value(cmd)
-    assert val.get_value() == cmd
+    assert val['name'] != cmd
+    val['name'] = cmd
+    assert val['name'] == cmd
 
 
 def test_value_request(db, payment):
@@ -173,22 +135,22 @@ def test_value_request(db, payment):
     cmd = CommandRequestObject(PaymentCommand(payment))
     cmd.cid = '10'
 
-    val = StorableValue(db, 'command', CommandRequestObject)
-    val.set_value(cmd)
-    assert val.get_value() == cmd
+    val = StorableDict(db, 'command', CommandRequestObject)
+    val['name'] = cmd
+    assert val['name'] == cmd
 
     cmd.response = make_success_response(cmd)
     assert cmd.response is not None
-    assert val.get_value() != cmd
-    assert val.get_value().response is None
+    assert val['name'] != cmd
+    assert val['name'].response is None
 
-    val.set_value(cmd)
-    assert val.get_value() == cmd
+    val['name'] = cmd
+    assert val['name'] == cmd
 
     cmd.response = make_command_error(cmd, code=OffChainErrorCode.test_error_code)
-    assert val.get_value() != cmd
-    val.set_value(cmd)
-    assert val.get_value() == cmd
+    assert val['name'] != cmd
+    val['name'] = cmd
+    assert val['name'] == cmd
 
 def test_dict_trans():
     db = BasicStore.mem()

--- a/src/offchainapi/tests/test_storable.py
+++ b/src/offchainapi/tests/test_storable.py
@@ -12,14 +12,17 @@ import pytest
 
 def test_dict(db):
     D = StorableDict(db, 'mary', int)
+    assert D.is_empty()
     D['x'] = 10
+    assert not D.is_empty()
+
     assert D['x'] == 10
-    assert len(D) == 1
+    assert len(list(D.keys())) == 1
     D['hello'] = 2
-    assert len(D) == 2
+    assert len(list(D.keys())) == 2
     del D['x']
     assert D['hello'] == 2
-    assert len(D) == 1
+    assert len(list(D.keys())) == 1
     assert 'hello' in D
     assert 'x' not in D
 
@@ -59,7 +62,7 @@ def test_dict_dict_del_to_empty():
     del D['x']
     D['y'] = True
     del D['y']
-    assert len(D) == 0
+    assert len(list(D.keys())) == 0
 
 
 def test_dict_index():
@@ -67,12 +70,12 @@ def test_dict_index():
     D = StorableDict(db, 'mary', int)
     D['x'] = 10
     assert D['x'] == 10
-    assert len(D) == 1
+    assert len(list(D.keys())) == 1
     D['hello'] = 2
-    assert len(D) == 2
+    assert len(list(D.keys())) == 2
     del D['x']
     assert D['hello'] == 2
-    assert len(D) == 1
+    assert len(list(D.keys())) == 1
     assert 'hello' in D
     assert 'x' not in D
 
@@ -239,8 +242,8 @@ def test_dict_trans():
 
     with store as _:
         x = eg['x']
-        l = len(eg)
+        #l = len(eg)
         eg['z'] = 20
 
-    assert len(eg) == 3
+    assert len(list(eg.keys())) == 3
     assert set(eg.keys()) == set(['x', 'y', 'z'])

--- a/src/offchainapi/tests/test_storable.py
+++ b/src/offchainapi/tests/test_storable.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Tests for the storage framework
-from ..storage import StorableDict, StorableList, StorableValue, StorableFactory
+from ..storage import StorableDict, StorableValue, StorableFactory
 from ..payment_logic import PaymentCommand
 from ..protocol_messages import make_success_response, CommandRequestObject, \
     make_command_error
@@ -77,39 +77,6 @@ def test_dict_index():
     assert 'x' not in D
 
 
-def test_list(db):
-    lst = StorableList(db, 'jacklist', int)
-    lst += [1]
-    assert len(lst) == 1
-    assert lst[0] == 1
-    lst += [2]
-    assert len(lst) == 2
-    lst[0] = 10
-    assert lst[0] == 10
-    lst2 = StorableList(db, 'jacklist', int)
-    assert len(lst2) == 2
-    assert lst2[0] == 10
-
-    assert list(lst2) == [10, 2]
-
-
-def test_list_dict():
-    db = {}
-    lst = StorableList(db, 'jacklist', int)
-    lst += [1]
-    assert len(lst) == 1
-    assert lst[0] == 1
-    lst += [2]
-    assert len(lst) == 2
-    lst[0] = 10
-    assert lst[0] == 10
-    lst2 = StorableList(db, 'jacklist', int)
-    assert len(lst2) == 2
-    assert lst2[0] == 10
-
-    assert list(lst2) == [10, 2]
-
-
 def test_value(db):
     # Test default
     val0 = StorableValue(db, 'counter_zero', int, default=0)
@@ -158,10 +125,6 @@ def test_value_payment(db, payment):
     assert val.exists() is True
     pay2 = val.get_value()
     assert payment == pay2
-
-    lst = StorableList(db, 'jacklist', payment.__class__)
-    lst += [payment]
-    assert lst[0] == pay2
 
     D = StorableDict(db, 'mary', payment.__class__)
     D[pay2.version] = pay2


### PR DESCRIPTION
## Motivation

Simplify the storage subsystem of the offchain reference:
- Removed the RLocks, given the current architecture (single threat IO) it did not do anything, but was untested and misled into thinking it does something.
- Remove the need for storable values & lists (now only uses maps).
- Limited the number of stored structures and consolidated them.
- Created a backend using sqlite3, that natively supports transactions, commit, rollback
- Removed custom indexes (linked lists) from StorableDict and use sql select in backend

Unrelated:
- Fixed a bug in payment logic relating to soft_match.
- Fixed liveness bug that prevented retransmit on unknown dependency.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added unit tests for new storage, and adapted perf end-to-end tests.
